### PR TITLE
Fix bug in selectionChange event when selecting objects using ctrl-click (command click on mac).

### DIFF
--- a/controls/diagrams/spec/diagram/interaction/events.spec.ts
+++ b/controls/diagrams/spec/diagram/interaction/events.spec.ts
@@ -63,6 +63,28 @@ describe('Diagram Control', () => {
                 mouseEvents.clickEvent(diagramCanvas, 250 + 8, 250 + 8);
                 done();
             });
+
+            it('Checking selection Change for multiple ctrl click select', (done: Function) => {
+                let diagramCanvas: HTMLElement = document.getElementById(diagram.element.id + 'content');
+                diagram.selectionChange = (args: ISelectionChangeEventArgs) => {
+                    if (args.state === 'Changed') {
+                        expect(args.oldValue.length === 0 && args.newValue.length === 1 && args.newValue[0].id == 'node1').toBe(true);
+                    }
+                };
+                mouseEvents.clickEvent(diagramCanvas, 100 + 8, 100 + 8);
+
+                diagram.selectionChange = (args: ISelectionChangeEventArgs) => {
+                    if (args.state === 'Changed') {
+                        expect(args.oldValue.length === 1 &&
+                               args.newValue.length === 2 &&
+                               args.newValue[0].id == 'node1' &&
+                               args.newValue[1].id == 'node2'
+                        ).toBe(true);
+                    }
+                };
+                mouseEvents.clickEvent(diagramCanvas, 150 + 8, 150 + 8, true);
+                done();
+            });
         });
     });
     describe('Testing event', () => {

--- a/controls/diagrams/src/diagram/interaction/tool.ts
+++ b/controls/diagrams/src/diagram/interaction/tool.ts
@@ -307,7 +307,7 @@ export class SelectTool extends ToolBase {
                 //handling multiple selection
                 if (args && args.source) {
                     if (!this.commandHandler.isSelected(args.source)) {
-                        this.commandHandler.selectObjects([args.source], true);
+                        this.commandHandler.selectObjects([...arrayNodes, args.source], true, arrayNodes);
                     } else {
                         if (args.clickCount === 1) {
                             this.commandHandler.unSelect(args.source);


### PR DESCRIPTION
When selecting multiple items using ctrl-click, the selectionChange event emits an event where the oldValue array has 0 items and newValue array has 1 item when selecting the first item. 

But when selecting the second item, the oldValue array incorrectly has 0 items and newValue incorrectly has 1 item. The expected behavior is that on the second ctrl-selection, the oldValue has 1 item and newValue has 2 items.

NOTE: I unfortunately was not able to get either `npm run build` or `npm test` working locally to verify that the fix worked. If y'all have any guidance there, that would be much appreciated :)