### PR TITLE
maps-subLayer: extend new object when initiating tiles for a OSM or Bing map subLayer

### DIFF
--- a/controls/maps/src/maps/layers/layer-panel.ts
+++ b/controls/maps/src/maps/layers/layer-panel.ts
@@ -690,7 +690,7 @@ export class LayerPanel {
             }
             if (layer.layerType === 'OSM' || layer.layerType === 'Bing') {
                 for (let baseTile of proxTiles) {
-                    let subtile: Tile = extend(baseTile, {}, {}, true) as Tile;
+                    let subtile: Tile = extend({}, baseTile, {}, true) as Tile;
                     if (layer.layerType === 'Bing') {
                         subtile.src = bing.getBingMap(subtile, layer.key, layer.bingMapType, userLang, bing.imageUrl, bing.subDomains);
                     } else {


### PR DESCRIPTION
currently when initiating a tile array for a sublayer the original tile is extended rather than extending a new object, this causes the original tiles src attribute to be overwritten so that you end up with two tile arrays pointing to the same object references. This change creates a new object from the original so that the arrays do not share the same object references.