### PR TITLE
RichTextEditor: Ensure prevLine is defined before subsequently calling .split on it

### DIFF
--- a/controls/richtexteditor/src/markdown-parser/plugin/lists.ts
+++ b/controls/richtexteditor/src/markdown-parser/plugin/lists.ts
@@ -265,7 +265,7 @@ export class MDLists {
         let start: number = textArea.selectionStart;
         let end: number = textArea.selectionEnd;
         let parents: { [key: string]: string | number }[] = this.selection.getSelectedParentPoints(textArea);
-        let prevLine: string = this.selection.getLine(textArea, (parents[0].line as number) - 1);
+        let prevLine: string = this.selection.getLine(textArea, (parents[0].line as number) - 1) || '';
         let listFormat: number = this.olListType();
         let regex: RegExp = this.getListRegex();
         let prevLineSplit: string[] = prevLine.split('. ');


### PR DESCRIPTION
Ensures that `prevLine` is defined before calling `split` on it, as well as any other function calls that follow.

Prevents the following error:
```
core.js:15723 ERROR TypeError: Cannot read property 'split' of undefined
    at MDLists.push../node_modules/@syncfusion/ej2-richtexteditor/src/markdown-parser/plugin/lists.js.MDLists.enterKey (lists.js:259)
    at MDLists.push../node_modules/@syncfusion/ej2-richtexteditor/src/markdown-parser/plugin/lists.js.MDLists.keyUpHandler (lists.js:44)
    at Observer.push../node_modules/@syncfusion/ej2-base/src/observer.js.Observer.notify (observer.js:99)
    at MarkdownParser.push../node_modules/@syncfusion/ej2-richtexteditor/src/markdown-parser/base/markdown-parser.js.MarkdownParser.editorKeyUp (markdown-parser.js:54)
    at Observer.push../node_modules/@syncfusion/ej2-base/src/observer.js.Observer.notify (observer.js:99)
    at MarkdownFormatter.push../node_modules/@syncfusion/ej2-richtexteditor/src/rich-text-editor/formatter/formatter.js.Formatter.onKeyHandler (formatter.js:102)
    at RichTextEditorComponent.push../node_modules/@syncfusion/ej2-richtexteditor/src/rich-text-editor/base/rich-text-editor.js.RichTextEditor.keyUp (rich-text-editor.js:395)
    at HTMLTextAreaElement.__trace__ (bugsnag.js:2211)
    at ZoneDelegate.push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask (zone.js:421)
    at Object.onInvokeTask (core.js:17289)
```