### PR TITLE
SplitButton: Prevent querySelector from running on undefined

### DIFF
--- a/controls/splitbuttons/src/drop-down-button/drop-down-button.ts
+++ b/controls/splitbuttons/src/drop-down-button/drop-down-button.ts
@@ -411,9 +411,12 @@ export class DropDownButton extends Component<HTMLButtonElement> implements INot
     }
 
     private removeCustomSelection(): void {
-        let selectedLi: Element = this.getULElement().querySelector('.e-selected');
-        if (selectedLi) {
-            selectedLi.classList.remove('e-selected');
+        let ul: Element = this.getULElement();
+        if (ul) {
+            let selectedLi: Element = ul.querySelector('.e-selected');
+            if (selectedLi) {
+                selectedLi.classList.remove('e-selected');
+            }
         }
     }
 


### PR DESCRIPTION
Check that the `ul` exists before possibly running `querySelector` on undefined.

Prevents the following error:
```
ERROR TypeError: Cannot read property 'querySelector' of undefined
    at DropDownButton.push../node_modules/@syncfusion/ej2-splitbuttons/src/drop-down-button/drop-down-button.js.DropDownButton.removeCustomSelection (drop-down-button.js:304)
    at Observer.<anonymous> (drop-down-button.js:411)
    at Observer.push../node_modules/@syncfusion/ej2-base/src/observer.js.Observer.notify (observer.js:84)
    at DropDownButton.push../node_modules/@syncfusion/ej2-base/src/base.js.Base.trigger (base.js:152)
    at DropDownButton.push../node_modules/@syncfusion/ej2-splitbuttons/src/drop-down-button/drop-down-button.js.DropDownButton.closePopup (drop-down-button.js:408)
    at DropDownButton.push../node_modules/@syncfusion/ej2-splitbuttons/src/drop-down-button/drop-down-button.js.DropDownButton.mousedownHandler (drop-down-button.js:351)
    at HTMLDocument.__trace__ (bugsnag.js:2211)
    at ZoneDelegate.push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask (zone.js:421)
    at Object.onInvokeTask (core.js:17289)
    at ZoneDelegate.push../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask (zone.js:420)
```