### PR TITLE
Pan map on mobile browser

### DIFF
--- a/controls/maps/src/maps/user-interaction/zoom.ts
+++ b/controls/maps/src/maps/user-interaction/zoom.ts
@@ -1458,7 +1458,7 @@ export class Zoom {
                     this.rectZoomingStart = false;
                     this.updateInteraction();
                     this.touchStartList = targetTouches(e);
-                } else if (this.touchStartList.length === 2 && touches.length === 2) {
+                } else if (touches.length === 2 && this.touchStartList.length === 2) {
                     this.touchMoveList = targetTouches(e);
                     e.preventDefault();
                     this.rectZoomingStart = false;

--- a/controls/maps/src/maps/user-interaction/zoom.ts
+++ b/controls/maps/src/maps/user-interaction/zoom.ts
@@ -1470,7 +1470,7 @@ export class Zoom {
         this.mouseMovePoints = this.getMousePosition(pageX, pageY);
         let targetId: string = e.target['id'];
         let targetEle: Element = <Element>e.target;
-        if (zoom.enable && this.isPanning && ((Browser.isDevice && touches.length > 1) || !Browser.isDevice)) {
+        if (zoom.enable && this.isPanning && ((Browser.isDevice && touches.length >= 1) || !Browser.isDevice)) {
             e.preventDefault();
             this.maps.element.style.cursor = 'pointer';
             this.mouseMoveLatLong = { x: pageX, y: pageY };


### PR DESCRIPTION
The map component doesn't pan on a mobile browser and throws an error.

This PR fixes the null reference exception and enables panning on a touch device.

I tested this change in a browser and on an emulated Android tablet.