### PR TITLE
PivotView Virtualscroll was throwing an error due tu css property syntax expectation on Firefox

### DIFF
--- a/controls/pivotview/src/pivotview/actions/virtualscroll.ts
+++ b/controls/pivotview/src/pivotview/actions/virtualscroll.ts
@@ -277,9 +277,10 @@ export class VirtualScroll {
             }
             this.direction = 'horizondal';
             let horiOffset: number = -((left - this.parent.scrollPosObject.horizontalSection - mCont.scrollLeft));
-            let vertiOffset: string = (mCont.querySelector('.' + cls.TABLE) as HTMLElement).style.transform.split(',')[1].trim();
+            const tableElement: HTMLElement = (mCont.querySelector('.' + cls.TABLE) as HTMLElement);
+            let vertiOffset: string = tableElement.style.transform.split(',')[1] ? tableElement.style.transform.split(',')[1].trim() : '0px)';
             if (mCont.scrollLeft < this.parent.scrollerBrowserLimit) {
-                setStyleAttribute(mCont.querySelector('.e-table') as HTMLElement, {
+                setStyleAttribute(tableElement, {
                     transform: 'translate(' + horiOffset + 'px,' + vertiOffset
                 });
                 setStyleAttribute(mHdr.querySelector('.e-table') as HTMLElement, {


### PR DESCRIPTION
onHorizondalScroll method of ` controls/pivotview/src/pivotview/actions/virtualscroll.ts` was expecting a second value in transform: translate() to compute updated offsets.

However Firefox is shortening `translate(<x>, <y>)` to `translate(<x>)` if y=0.
See [https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translate](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/translate) for reference.

This PR tests if the `y` value is present before appending the `y` part parsed from style to new `translate` value.

 