### PR TITLE
Do not access lastElementChild unless timeTr is present

### DIFF
--- a/controls/schedule/src/schedule/renderer/vertical-view.ts
+++ b/controls/schedule/src/schedule/renderer/vertical-view.ts
@@ -271,7 +271,9 @@ export class VerticalView extends ViewBase implements IRenderer {
         });
         if (rowIndex <= timeTrs.length) {
             removeClass(timeCellsWrap.querySelectorAll('.' + cls.HIDE_CHILDS_CLASS), cls.HIDE_CHILDS_CLASS);
-            addClass([timeTrs[rowIndex].lastElementChild as Element], cls.HIDE_CHILDS_CLASS);
+            if (timeTrs[rowIndex]) {
+                addClass([timeTrs[rowIndex].lastElementChild as Element], cls.HIDE_CHILDS_CLASS);
+            }
             prepend([currentTimeEle], timeCellsWrap);
             currentTimeEle.style.top = formatUnit(currentTimeEle.offsetTop - (currentTimeEle.offsetHeight / 2));
         }


### PR DESCRIPTION
We experience the issue, which doesn't really seem to affect our users, but that's just coming from Sentry frequently. And we don't know the reproduction yet, but in that way, as it's made in PR we can ensure that there is a value before accessing lastElementChild from it. Because sometimes, on some occasions `timeTrs[rowIndex]` is `undefined`. I am sure that would help SF as well, since nothing is really changed, just ensuring that there is a value behind `timeTrs[rowIndex` before accessing it's methods