### PR TITLE
Fix infinite cycle

### DIFF
--- a/controls/schedule/src/schedule/event-renderer/vertical-view.ts
+++ b/controls/schedule/src/schedule/event-renderer/vertical-view.ts
@@ -615,7 +615,7 @@ export class VerticalEvent extends EventBase {
             });
             for (let i: number = 0; i < appointment.length - 1; i++) {
                 for (let j: number = i + 1; j < appointment.length; j++) {
-                    if (appointment[i].Id === appointment[j].Id) {
+                    if (appointment[i][fieldMapping.id] === appointment[j][fieldMapping.id]) {
                         appointment.splice(j, 1); j--;
                     }
                 }


### PR DESCRIPTION
The id property is in this case incorrectly acccessed directly, ignoring the fact that it's name can be changed in field mapping. If the Id property is not filled, this results in an infinite cycle.