### PR TITLE
Do not access this in getTaskData

### DIFF
--- a/controls/gantt/src/gantt/base/utils.ts
+++ b/controls/gantt/src/gantt/base/utils.ts
@@ -108,7 +108,7 @@ export function getTaskData(
         for (let i: number = 0; i < records.length; i++) {
             let data: object;
             if (!isNullOrUndefined(parent) && parent.timezone) {
-                this.updateDates(records[i], parent);
+                updateDates(records[i], parent);
             }
             // eslint-disable-next-line
             data = isNotExtend ? (records[i].taskData) : extend({}, records[i].taskData, {}, true);


### PR DESCRIPTION
In the Methode getTaskData you cant acces this because it's undefined.
Problems only occurs when you set the timezone property on the ganttchart and try to edit some tasks.

Quick fix is just to remove this and everythink seems to work fine.