### PR TITLE
add SVG support when exporting to DOCX

### DIFF
--- a/controls/documenteditor/src/document-editor/implementation/editor/editor-helper.ts
+++ b/controls/documenteditor/src/document-editor/implementation/editor/editor-helper.ts
@@ -323,6 +323,9 @@ export class HelperMethods {
         } else if (this.startsWith(base64ImageString, 'data:image/x-wmf;base64,')) {
             extension = '.wmf';
             formatClippedString = base64ImageString.replace('data:image/x-wmf;base64,', '');
+        } else if (this.startsWith(base64ImageString, 'data:image/svg+xml;base64,')) {
+            extension = '.svg';
+            formatClippedString = base64ImageString.replace('data:image/svg+xml;base64,', '');
         } else {
             extension = '.jpeg';
         }


### PR DESCRIPTION
Currently, the library cuts out all byte content of the SVG format image when exporting to DOCX. This causes the image to not be exported. This change adds support for this format